### PR TITLE
Provide a default log to simplify basic usage

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -19,6 +19,7 @@ end library logging;
 
 define module logging
   create
+    *log*,
     <log>,
     log-formatter,
     log-formatter-setter,

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -27,4 +27,5 @@ define module logging-test-suite
   use operating-system,
     import: { current-process-id };
   use testworks;
+  use threads;
 end module;


### PR DESCRIPTION
It's no longer necessary to pass the log to log-info, log-debug, et al, nor to
create any `<log>` at all.

The default log goes to stderr.  Applications may set or dynamically bind
`*log*` to change this behavior.

This is an incompatible API change so I'll bump the version to 2.0.