### PR TITLE
Handle relative pathnames in rolling log targets

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -90,7 +90,6 @@ define module logging-impl
     exclude: { format-to-string };
   use date;
   use file-system;
-    //import: { <file-stream>, <pathname>, rename-file };
   use format;
   use generic-arithmetic,
     import: { <integer> => <double-integer>,
@@ -101,7 +100,8 @@ define module logging-impl
     import: { <locator>,
               <file-locator>,
               locator-name,
-              merge-locators };
+              merge-locators,
+              simplify-locator };
   use logging;
   use operating-system,
     import: { current-process-id };
@@ -114,6 +114,4 @@ define module logging-impl
     // for test suite
     elapsed-milliseconds,
     reset-logging;
-
 end module logging-impl;
-

--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -7,8 +7,7 @@ define library logging-test-suite
   use generic-arithmetic;
   use io;
   use logging;
-  use system,
-    import: { date, file-system, locators, operating-system };
+  use system;
   use testworks;
 end library;
 
@@ -21,11 +20,9 @@ define module logging-test-suite
   use logging;
   use logging-impl;
   use streams;
-  use file-system,
-    import: { delete-file, ensure-directories-exist, file-exists?, <pathname>, with-open-file };
+  use file-system;
   use locators;
-  use operating-system,
-    import: { current-process-id };
+  use operating-system;
   use testworks;
   use threads;
 end module;


### PR DESCRIPTION
If `<rolling-file-log-target>` is given a relative pathname and then
`working-directory()` is changed, when the log rolls it could open the new log
file in a different directory so merge against `working-directory()` when the
target is created.