### PR TITLE
Make `$stdout-log-target` work when `*standard-output*` is rebound

### DIFF
--- a/tests/library.dylan
+++ b/tests/library.dylan
@@ -23,6 +23,7 @@ define module logging-test-suite
   use file-system;
   use locators;
   use operating-system;
+  use standard-io;
   use testworks;
   use threads;
 end module;

--- a/tests/spec.dylan
+++ b/tests/spec.dylan
@@ -48,9 +48,29 @@ define test test-<stream-log-target> ()
 end test;
 
 define test test-$stderr-log-target ()
+  let ostream = make(<string-stream>, direction: #"output");
+  dynamic-bind (*log* = make(<log>,
+                             name: "stdout",
+                             targets: list($stdout-log-target),
+                             formatter: $message-only-formatter),
+                *standard-output* = ostream)
+    log-info("stdout");
+  end;
+  assert-equal("stdout\n", ostream.stream-contents,
+               "$stdout-log-target follows rebinding of *standard-output*");
 end test;
 
 define test test-$stdout-log-target ()
+  let ostream = make(<string-stream>, direction: #"output");
+  dynamic-bind (*log* = make(<log>,
+                             name: "stderr",
+                             targets: list($stderr-log-target),
+                             formatter: $message-only-formatter),
+                *standard-error* = ostream)
+    log-info("stderr");
+  end;
+  assert-equal("stderr\n", ostream.stream-contents,
+               "$stderr-log-target follows rebinding of *standard-error*");
 end test;
 
 define test test-<file-log-target> ()


### PR DESCRIPTION
This is useful because, for example, the http libraries do a lot of log output to the console during testing. Testworks has a general mechanims for capturing output from tests by rebinding `*standard-output*` and `*standard-error*`, and that only works if the log target didn't capture the value of one of those variables when it was created.